### PR TITLE
Fix cig bottom sidebar logo and improve documentation installation instructions

### DIFF
--- a/doc/sphinx_template/_templates/navbar_end.html
+++ b/doc/sphinx_template/_templates/navbar_end.html
@@ -1,1 +1,1 @@
-<img src="/en/latest/_static/images/cig_logo_dots.png" alt="CIG Logo" height="80px"  style="padding: 5px;"/>
+<img src="/en/latest/_static/cig_logo_dots.png" alt="CIG Logo" height="80px"  style="padding: 5px;"/>

--- a/doc/sphinx_template/index.md
+++ b/doc/sphinx_template/index.md
@@ -12,7 +12,37 @@
 
  Files here are in markdown (md) but you can use  and mix in reStructuredText (rst) as well.
 
-### License
+## About this documentation
+
+ This template uses the latest versions of the following python packages:
+
+* sphinx 4.2.0
+* sphinx-book-theme 1.0.1
+* python 3.9.7
+* myst-parser 0.18.1          &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; *if using rst*
+* nbsphinx 0.9.2
+* sphinxcontrib-bibtex 2.5.0
+
+ If you want to build this documentation locally
+ use `conda install` or `pip install` to install the packages. Alternatively,
+ you can also use the file [environment.yml](https://github.com/geodynamics/software_template/blob/main/doc/sphinx_template/environment.yml) to create a new conda environment
+ with all packages as `conda env create -f environment.yml`.
+
+## Building
+
+To build this html documentation locally, execute in the main directory `sphinx_template`:
+
+```
+make html
+```
+
+This creates the `_build/html` directory.
+
+Open `index.html` to display your manual in a browser window.
+
+See [https://readthedocs.org/](https://readthedocs.org/) for online hosting of your manual.
+
+## License
 
 *My Project* is published under the GNU GPL v3 or newer license.
 

--- a/doc/sphinx_template/user/install.md
+++ b/doc/sphinx_template/user/install.md
@@ -1,13 +1,7 @@
 (cha:installation)=
 # Installation
 
-This template uses the latest versions of the following:
-
- *  sphinx 4.2.0
- *  sphinx-book-theme 1.0.1
- *  python 3.9.7
- *  myst-parser 0.18.1          &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; *if using rst*
- *  nbsphinx 0.9.2
- *  sphinxcontrib-bibtex 2.5.0
-
- Use `conda install` or `pip install`.
+Include instructions for how to install your software. This page can also reference
+your [INSTALL](https://github.com/geodynamics/software_template/blob/main/INSTALL)
+or [README.md](https://github.com/geodynamics/software_template/blob/main/README.md#installation-instructions)
+file.

--- a/doc/sphinx_template/user/run.md
+++ b/doc/sphinx_template/user/run.md
@@ -1,14 +1,4 @@
 (cha:run-aspect)=
 # Running *My Project*
 
-
-To create html documentation, from the main directory `docs`:
-```
-make html
-```
-
-This creates the `_build` directory.  
-
-Select `index.html` to display your manual in a browser window.
-
-See [https://readthedocs.org/](https://readthedocs.org/) for online hosting of your manual.
+Instructions for how to run *My Project*.


### PR DESCRIPTION
Fix for the CIG bottom sidebar logo.

I also moved the installation instruction for the documentation onto the front page, because this is likely something users want to see early in this template. I replaced the text in the install and run sections with text that is relevant for the software project itself (instead of the documentation template).

This PR will also test if readthedocs correctly builds for pull requests.