### PR TITLE
Switch changelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+with the addition of author(s), date of change and optionally the relevant issue. 
+
+Add new entries a the bottom of the unreleased list. Item format: 
+- Description. [Name; date; relevant github issue tag(s) and or pull requests]
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+- Switched the change log format from a self-written CHANGES file to the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. [Rene Gassmoeller; 2024-03-29; https://github.com/geodynamics/software_template/pull/7]
+
+### Removed
+
+## [1.0.0] - 2024-03-29
+
+### Added
+
+- Released the first version of the software template repository.
+
+[unreleased]: https://github.com/geodynamics/software_template/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/geodynamics/software_template/releases/tag/v1.0.0

--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,0 @@
-SOFTWARE_TEMPLATE Version history:
-
-SOFTWARE_TEMPLATE 1.0:
-
-We are pleased to announce the release of the CIG Software Template 1.0. This
-template consists of a repository that illustrates our software [best
-practices](https://github.com/geodynamics/best_practices) and allows software
-projects to easily adapt these practices.


### PR DESCRIPTION
As discussed in the CIG best practices hackathon, switch the format of the changelog file to the one suggested by https://github.com/olivierlacan/keep-a-changelog and already used by https://github.com/GeodynamicWorldBuilder/WorldBuilder.